### PR TITLE
Client side sim to sim data syncing, queuing for getSetData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release History
 
+- Unreleased
+    - New SimCapiMessage Types:
+        - REGISTER_LOCAL_DATA_CHANGE_LISTENER,
+        - REGISTERED_LOCAL_DATA_CHANGED
+       *        New public transporter method: registerLocalDataListener
 - 1.2.1 (05 Dec 2016)
     - Some clean up and making the project Jenkins ready.
 - 1.2.0 (21 Oct 2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Release History
 
 - Unreleased
+    - Remove try-catch block surrounding response callbacks (BREAKING CHANGE)
+    - Queueing (single latest) requests for get/setData while an existing request is running
     - New SimCapiMessage Types:
         - REGISTER_LOCAL_DATA_CHANGE_LISTENER,
         - REGISTERED_LOCAL_DATA_CHANGED

--- a/app/scripts/api/snapshot/ApiInterface.js
+++ b/app/scripts/api/snapshot/ApiInterface.js
@@ -40,10 +40,10 @@ define(function(require) {
 
     ApiInterface.prototype.apiCall = function(api, method, params, callback) {
         if (!apiList[api]) {
-            throw new Error('Invalid api name provided');
+            throw new Error('Invalid api name provided: ' + api);
         }
         if (apiList[api].indexOf(method) === -1) {
-            throw new Error('Method does not exist on the api');
+            throw new Error('Method does not exist on the api: ' + method);
         }
 
         var uid = ++this.apiCallUid;

--- a/app/scripts/api/snapshot/SimCapiMessage.js
+++ b/app/scripts/api/snapshot/SimCapiMessage.js
@@ -19,20 +19,20 @@
 
 define(function(require) {
 
-    var SimCapiMessage = function(options) {
+    var SimCapiMessage = function(params) {
 
-        // Ensure that options is initialized. This is just making code cleaner by avoiding lots of
+        // Ensure that params is initialized. This is just making code cleaner by avoiding lots of
         // null checks
-        options = options || {};
+        params = params || {};
 
         // The message type. Select from TYPES.
-        this.type = options.type || null;
+        this.type = params.type || null;
 
         /*
          * This is needed to create a handshake between stage and iframe. Without a handshake,
          * we can't identify the IFrame from which a message was sent.
          */
-        this.handshake = options.handshake || {
+        this.handshake = params.handshake || {
             requestToken: null,
             authToken: null
         };
@@ -40,12 +40,17 @@ define(function(require) {
         /*
          * Values is a map containing (key, CapiValue) pairs.
          */
-        this.values = options.values || {};
+        this.values = params.values || {};
+
+        /*
+         * Optional options object to be passed to the viewer
+         */
+        this.options = params.options || {};
     };
 
     /*
      * Define message type enums as a class variable.
-     * Next number is 21
+     * Next number is 23
      */
     SimCapiMessage.TYPES = {
         HANDSHAKE_REQUEST: 1,
@@ -66,7 +71,9 @@ define(function(require) {
         API_CALL_RESPONSE: 17,
         RESIZE_PARENT_CONTAINER_REQUEST: 18,
         RESIZE_PARENT_CONTAINER_RESPONSE: 19,
-        ALLOW_INTERNAL_ACCESS: 20
+        ALLOW_INTERNAL_ACCESS: 20,
+        REGISTER_LOCAL_DATA_CHANGE_LISTENER: 21,
+        LOCAL_DATA_CHANGED: 22
     };
 
     return SimCapiMessage;

--- a/app/scripts/api/snapshot/SimCapiMessage.js
+++ b/app/scripts/api/snapshot/SimCapiMessage.js
@@ -73,7 +73,7 @@ define(function(require) {
         RESIZE_PARENT_CONTAINER_RESPONSE: 19,
         ALLOW_INTERNAL_ACCESS: 20,
         REGISTER_LOCAL_DATA_CHANGE_LISTENER: 21,
-        LOCAL_DATA_CHANGED: 22
+        REGISTERED_LOCAL_DATA_CHANGED: 22
     };
 
     return SimCapiMessage;

--- a/app/scripts/api/snapshot/Transporter.js
+++ b/app/scripts/api/snapshot/Transporter.js
@@ -242,7 +242,6 @@ define(function(require) {
         };
 
         /*
-         *   @since 0.5, queueing behaviour since 2.0
          *   Handles the get data message
          */
         var handleGetDataResponse = function(message) {
@@ -268,7 +267,6 @@ define(function(require) {
         };
 
         /*
-         *   @since 0.5, queueing behaviour since 2.0
          *   Handles the set data message
          */
         var handleSetDataResponse = function(message) {
@@ -294,7 +292,6 @@ define(function(require) {
 
 
         /*
-         * @since 0.5, queueing behaviour since 2.0
          * Sends the GET_DATA Request
          */
         this.getDataRequest = function(simId, key, onSuccess, onError) {
@@ -345,7 +342,6 @@ define(function(require) {
         };
 
         /*
-         * @since 0.5, queueing behaviour since 2.0
          * Sends the SET_DATA Request
          */
         this.setDataRequest = function(simId, key, value, onSuccess, onError, options) {

--- a/app/scripts/api/snapshot/Transporter.js
+++ b/app/scripts/api/snapshot/Transporter.js
@@ -644,6 +644,9 @@ define(function(require) {
          * Register the sim to be notified when local data changes
          */
         this.registerLocalDataListener = function(simId, key, callback) {
+            check(simId).isString();
+            check(key).isString();
+
             var message = new SimCapiMessage({
                 type: SimCapiMessage.TYPES.REGISTER_LOCAL_DATA_CHANGE_LISTENER,
                 handshake: this.getHandshake(),

--- a/app/scripts/api/snapshot/Transporter.js
+++ b/app/scripts/api/snapshot/Transporter.js
@@ -154,7 +154,7 @@ define(function(require) {
                 case SimCapiMessage.TYPES.ALLOW_INTERNAL_ACCESS:
                     setDomainToShortform();
                     break;
-                case SimCapiMessage.TYPES.LOCAL_DATA_CHANGED:
+                case SimCapiMessage.TYPES.REGISTERED_LOCAL_DATA_CHANGED:
                     handleLocalDataChange(message);
                     break;
             }

--- a/app/scripts/api/snapshot/Transporter.js
+++ b/app/scripts/api/snapshot/Transporter.js
@@ -640,6 +640,10 @@ define(function(require) {
             }
         };
 
+        function unregisterLocalDataListener(simId, key) {
+            delete self.localDataChangedCallbacks[simId][key];
+        }
+
         /*
          * Register the sim to be notified when local data changes
          */
@@ -660,6 +664,8 @@ define(function(require) {
             self.localDataChangedCallbacks[simId][key] = callback;
 
             self.sendMessage(message);
+
+            return unregisterLocalDataListener.bind(this, simId, key);
         };
 
         /*

--- a/test/specs/api/snapshot/Transporter.spec.js
+++ b/test/specs/api/snapshot/Transporter.spec.js
@@ -99,6 +99,40 @@ define(function(require) {
             };
         };
 
+        describe('on window message', function() {
+            var messageEventHandler, fakeMessageEvent;
+            beforeEach(function() {
+                messageEventHandler = window.addEventListener.getCall(0).args[1];
+
+                var message = {
+                    type: SimCapiMessage.TYPES.GET_DATA_REQUEST,
+                    handshake: 'handshake',
+                    values: {
+                        key: 'key',
+                        simId: 'simId'
+                    }
+                };
+
+                fakeMessageEvent = { data: JSON.stringify(message) };
+
+                sandbox.stub(transporter, 'capiMessageHandler');
+            });
+
+            it('should call the capiMessageHandler', function() {
+                messageEventHandler(fakeMessageEvent);
+
+                expect(transporter.capiMessageHandler.callCount).to.equal(1);
+            });
+
+            it('should do nothing if it was not a valid JSON string', function() {
+                fakeMessageEvent.data = 'not a valid JSON you dummy';
+
+                messageEventHandler(fakeMessageEvent);
+
+                expect(transporter.capiMessageHandler.callCount).to.equal(0);
+            });
+        });
+
         describe('HANDSHAKE_REQUEST', function() {
 
             it('should send a requestHandshake when trying to send ON_READY notification', function() {

--- a/test/specs/api/snapshot/Transporter.spec.js
+++ b/test/specs/api/snapshot/Transporter.spec.js
@@ -1401,11 +1401,11 @@ define(function(require) {
             });
         });
 
-        describe('LOCAL_DATA_CHANGED', function() {
+        describe('REGISTERED_LOCAL_DATA_CHANGED', function() {
             var response, localDataChangeCallback;
             beforeEach(function() {
                 response = new SimCapiMessage({
-                    type: SimCapiMessage.TYPES.LOCAL_DATA_CHANGED,
+                    type: SimCapiMessage.TYPES.REGISTERED_LOCAL_DATA_CHANGED,
                     handshake: {
                         authToken: authToken
                     },

--- a/test/specs/api/snapshot/Transporter.spec.js
+++ b/test/specs/api/snapshot/Transporter.spec.js
@@ -1502,6 +1502,16 @@ define(function(require) {
 
                 expect(transporter.localDataChangedCallbacks['sim']['key']).to.be(callbackStub);
             });
+
+            it('should return a function to unregister the listener', function() {
+                var unregister = transporter.registerLocalDataListener('sim', 'key', callbackStub);
+
+                expect(transporter.localDataChangedCallbacks['sim']['key']).to.be(callbackStub);
+
+                unregister();
+
+                expect(transporter.localDataChangedCallbacks['sim']['key']).to.be(undefined);
+            });
         });
     });
 });


### PR DESCRIPTION
* Allow sims to 'register' in the viewer for notifications of when a simId + key pair value changes
* Additional 'options' parameter passed to `setDataRequest`, with expected `syncWithLocal: true` key to allow other registered sims (including itself) to be notified of the change. `options` will default to an empty object for all SimCapiMessages
* Queuing behaviour for `getData` and `setData` requests, if a request is currently being made. Additional queued requests will overwrite the 'latest pending' request.
* Remove try-catch block surrounding success/error callbacks on capi message receives to provide better error handling (BREAKING CHANGE)

Code is ready for review, marked as WIP pending the latest 'control' message for initial config properties to be implemented